### PR TITLE
Fix, reading from '-base' images

### DIFF
--- a/.github/workflows/release-runner-images.yaml
+++ b/.github/workflows/release-runner-images.yaml
@@ -52,7 +52,7 @@ jobs:
           file: ./${{ matrix.runner }}.Dockerfile
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           build-args: |
-            BASE_IMAGE=ghcr.io/weaveworks/tf-runner:${{ env.VERSION }}
+            BASE_IMAGE=ghcr.io/weaveworks/tf-runner:${{ env.VERSION }}-base
             TF_VERSION=${{ matrix.tf_version }}
           tags: |
             ghcr.io/tf-controller/tf-runner:${{ env.VERSION }}-${{ matrix.runner }}-tf-${{ matrix.tf_version }}-mpl
@@ -98,7 +98,7 @@ jobs:
           file: ./${{ matrix.runner }}.Dockerfile
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           build-args: |
-            BASE_IMAGE=ghcr.io/weaveworks/tf-runner:${{ env.VERSION }}
+            BASE_IMAGE=ghcr.io/weaveworks/tf-runner:${{ env.VERSION }}-base
             TF_VERSION=${{ matrix.tf_version }}
           tags: |
             ghcr.io/tf-controller/tf-runner:${{ env.VERSION }}-${{ matrix.runner }}-tf-${{ matrix.tf_version }}-bsl

--- a/aws.Dockerfile
+++ b/aws.Dockerfile
@@ -26,15 +26,15 @@ ARG TF_VERSION
 # Switch to root to have permissions for operations
 USER root
 
-# terraform
-ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip /usr/local/bin/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip
-RUN unzip -q /usr/local/bin/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
-    rm /usr/local/bin/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
-    chmod +x /usr/local/bin/terraform
-
 #aws-cli
 COPY --from=aws-builder /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=aws-builder /aws-cli-bin/ /usr/local/bin/
+
+# terraform
+ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip terraform_${TF_VERSION}_linux_${TARGETARCH}.zip
+RUN unzip -q terraform_${TF_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
+    rm terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
+    chmod +x /usr/local/bin/terraform
 
 # Switch back to the non-root user after operations
 USER 65532:65532

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -8,9 +8,9 @@ ARG TF_VERSION
 USER root
 
 # terraform
-ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip /usr/local/bin/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip
-RUN unzip -q /usr/local/bin/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
-    rm /usr/local/bin/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
+ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip terraform_${TF_VERSION}_linux_${TARGETARCH}.zip
+RUN unzip -q terraform_${TF_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
+    rm terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
     chmod +x /usr/local/bin/terraform
 
 # Switch back to the non-root user after operations


### PR DESCRIPTION
Please start the workflow to build new images. 

Description:
tf-controllerr base image is now used as base image. I also had problems with the terraform binary not updating in newly added layers. I fixed that too. 
