### PR TITLE
Tofu

### DIFF
--- a/.github/workflows/release-runner-images.yaml
+++ b/.github/workflows/release-runner-images.yaml
@@ -20,9 +20,11 @@ env:
 jobs:
   release-tofu:
     runs-on: ubuntu-latest
+    env:
+      INFRA_EXEC_NAME: tofu
     strategy:
       matrix:
-        tofu_version: [v1.6.0-alpha1, v1.6.0-alpha2, v1.6.0-alpha3, v1.6.0-alpha4, v1.6.0-alpha5]
+        tofu_version: [1.6.0-alpha1, 1.6.0-alpha2, 1.6.0-alpha3, 1.6.0-alpha4, 1.6.0-alpha5] 
         runner: [base, aws]
     steps:
       - name: Check out
@@ -42,7 +44,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish multi-arch tf-${{ matrix.runner }} MPL images
+      - name: Publish multi-arch tofu-${{ matrix.runner }} images
         uses: docker/build-push-action@v5
         with:
           push: true
@@ -54,10 +56,10 @@ jobs:
           build-args: |
             BASE_IMAGE=ghcr.io/weaveworks/tf-runner:${{ env.VERSION }}-base
             INFRA_EXEC_VERSION=${{ matrix.tofu_version }}
-            INFRA_EXEC_NAME=tofu
-            INFRA_EXEC_URL_PREFIX=https://github.com/opentofu/opentofu/releases/download/
+            INFRA_EXEC_NAME=${{ env.INFRA_EXEC_NAME }}
+            INFRA_EXEC_URL_PREFIX=https://github.com/opentofu/opentofu/releases/download/v
           tags: |
-            ghcr.io/tf-controller/tf-runner:${{ env.VERSION }}-${{ matrix.runner }}-tf-${{ matrix.tofu_version }}-mpl
+            ghcr.io/tf-controller/${{ env.INFRA_EXEC_NAME }}-runner:${{ env.VERSION }}-${{ matrix.runner }}-tofu-${{ matrix.tofu_version }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -68,6 +70,8 @@ jobs:
 
   release-mpl:
     runs-on: ubuntu-latest
+    env:
+      INFRA_EXEC_NAME: terraform
     strategy:
       matrix:
         tf_version: [1.0.11, 1.1.9, 1.2.9, 1.3.10, 1.4.7, 1.5.7]
@@ -101,7 +105,9 @@ jobs:
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           build-args: |
             BASE_IMAGE=ghcr.io/weaveworks/tf-runner:${{ env.VERSION }}-base
-            TF_VERSION=${{ matrix.tf_version }}
+            INFRA_EXEC_VERSION=${{ matrix.tf_version }}
+            INFRA_EXEC_NAME=${{ env.INFRA_EXEC_NAME }}
+            INFRA_EXEC_URL_PREFIX=https://releases.hashicorp.com/terraform/
           tags: |
             ghcr.io/tf-controller/tf-runner:${{ env.VERSION }}-${{ matrix.runner }}-tf-${{ matrix.tf_version }}-mpl
           labels: |
@@ -114,6 +120,8 @@ jobs:
 
   release-bsl:
     runs-on: ubuntu-latest
+    env:
+      INFRA_EXEC_NAME: terraform
     strategy:
       matrix:
         tf_version: [1.6.0-beta2]
@@ -147,7 +155,9 @@ jobs:
           platforms: linux/amd64,linux/arm64 #,linux/arm/v7
           build-args: |
             BASE_IMAGE=ghcr.io/weaveworks/tf-runner:${{ env.VERSION }}-base
-            TF_VERSION=${{ matrix.tf_version }}
+            INFRA_EXEC_VERSION=${{ matrix.tf_version }}
+            INFRA_EXEC_NAME=${{ env.INFRA_EXEC_NAME }}
+            INFRA_EXEC_URL_PREFIX=https://releases.hashicorp.com/terraform/
           tags: |
             ghcr.io/tf-controller/tf-runner:${{ env.VERSION }}-${{ matrix.runner }}-tf-${{ matrix.tf_version }}-bsl
           labels: |

--- a/.github/workflows/release-runner-images.yaml
+++ b/.github/workflows/release-runner-images.yaml
@@ -18,6 +18,54 @@ env:
   VERSION: ${{ github.event.inputs.version }}
 
 jobs:
+  release-tofu:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tofu_version: [v1.6.0-alpha1, v1.6.0-alpha2, v1.6.0-alpha3, v1.6.0-alpha4, v1.6.0-alpha5]
+        runner: [base, aws]
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: "--debug"
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish multi-arch tf-${{ matrix.runner }} MPL images
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          no-cache: true
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./${{ matrix.runner }}.Dockerfile
+          platforms: linux/amd64,linux/arm64 #,linux/arm/v7
+          build-args: |
+            BASE_IMAGE=ghcr.io/weaveworks/tf-runner:${{ env.VERSION }}-base
+            INFRA_EXEC_VERSION=${{ matrix.tofu_version }}
+            INFRA_EXEC_NAME=tofu
+            INFRA_EXEC_URL_PREFIX=https://github.com/opentofu/opentofu/releases/download/
+          tags: |
+            ghcr.io/tf-controller/tf-runner:${{ env.VERSION }}-${{ matrix.runner }}-tf-${{ matrix.tofu_version }}-mpl
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.VERSION }}
+            org.opencontainers.image.created=${{ env.BUILD_DATE }}
+
   release-mpl:
     runs-on: ubuntu-latest
     strategy:

--- a/aws.Dockerfile
+++ b/aws.Dockerfile
@@ -21,7 +21,9 @@ RUN find /usr/local/aws-cli/v2/current/dist/awscli/botocore/data -name examples-
 
 FROM $BASE_IMAGE
 ARG TARGETARCH
-ARG TF_VERSION
+ARG INFRA_EXEC_VERSION
+ARG INFRA_EXEC_URL_PREFIX
+ARG INFRA_EXEC_NAME
 
 # Switch to root to have permissions for operations
 USER root
@@ -31,9 +33,10 @@ COPY --from=aws-builder /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=aws-builder /aws-cli-bin/ /usr/local/bin/
 
 # terraform
-ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip terraform_${TF_VERSION}_linux_${TARGETARCH}.zip
-RUN unzip -q terraform_${TF_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
-    rm terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
+ADD ${INFRA_EXEC_URL_PREFIX}${INFRA_EXEC_VERSION}/${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip
+RUN unzip -q ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
+    rm ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip && \
+    mv /usr/local/bin/${INFRA_EXEC_NAME} /usr/local/bin/terraform && \
     chmod +x /usr/local/bin/terraform
 
 # Switch back to the non-root user after operations

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -10,9 +10,7 @@ ARG INFRA_EXEC_NAME
 USER root
 
 # terraform
-# https://github.com/opentofu/opentofu/releases/download/v1.6.0-alpha5/tofu_1.6.0-alpha5_darwin_amd64.zip
-# ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip terraform_${TF_VERSION}_linux_${TARGETARCH}.zip
-ADD ${INFRA_EXEC_URL_PREFIX}/${INFRA_EXEC_VERSION}/${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip
+ADD ${INFRA_EXEC_URL_PREFIX}${INFRA_EXEC_VERSION}/${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip
 RUN unzip -q ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
     rm ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip && \
     mv /usr/local/bin/${INFRA_EXEC_NAME} /usr/local/bin/terraform && \

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -2,15 +2,20 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
-ARG TF_VERSION
+ARG INFRA_EXEC_VERSION
+ARG INFRA_EXEC_URL_PREFIX
+ARG INFRA_EXEC_NAME
 
 # Switch to root to have permissions for operations
 USER root
 
 # terraform
-ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip terraform_${TF_VERSION}_linux_${TARGETARCH}.zip
-RUN unzip -q terraform_${TF_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
-    rm terraform_${TF_VERSION}_linux_${TARGETARCH}.zip && \
+# https://github.com/opentofu/opentofu/releases/download/v1.6.0-alpha5/tofu_1.6.0-alpha5_darwin_amd64.zip
+# ADD https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${TARGETARCH}.zip terraform_${TF_VERSION}_linux_${TARGETARCH}.zip
+ADD ${INFRA_EXEC_URL_PREFIX}/${INFRA_EXEC_VERSION}/${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip
+RUN unzip -q ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin/ && \
+    rm ${INFRA_EXEC_NAME}_${INFRA_EXEC_VERSION}_linux_${TARGETARCH}.zip && \
+    mv /usr/local/bin/${INFRA_EXEC_NAME} /usr/local/bin/terraform && \
     chmod +x /usr/local/bin/terraform
 
 # Switch back to the non-root user after operations


### PR DESCRIPTION
This patch enables us to build opentofu runners as well as MPL and BPL terraform images. 

This should address https://github.com/weaveworks/tf-controller/issues/1132 to some extent although we might need to add something to the tf-controller documentation too.

Also, at present it creates the tofu binary as `/usr/local/bin/terraform`, I think we need some changes to the terraform controller to be able to set the exec path? I'll raise an issue for this in tf-controller repository.

I need to update the readme here, I'll do that but wanted to get this PR up for review before I spent time on that.
